### PR TITLE
Move the PHP requirement to a normal requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,10 @@
             "src/"
         ]
     },
+    "require": {
+        "php": "~5.3 || ~7.0"
+    },
     "require-dev": {
-        "php"                           : ">=5.3|~7.0",
         "phpunit/phpunit"               : "^4|^5|^7",
         "php-coveralls/php-coveralls"   : "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         ]
     },
     "require": {
-        "php": "~5.3 || ~7.0"
+        "php": "~5.4 || ~7.0"
     },
     "require-dev": {
         "phpunit/phpunit"               : "^4|^5|^7",


### PR DESCRIPTION
PHP is required to use the library, not only to develop it, and this ensures that future versions can bump the PHP min version safely as composer will then know about it.