### PR TITLE
Optimize the check of domains

### DIFF
--- a/src/IsBizMail.php
+++ b/src/IsBizMail.php
@@ -62,11 +62,13 @@ class IsBizMail
         }
 
         foreach (self::$freeMailDomains as $freeDomain) {
-            if (false === stripos($freeDomain, '*') && $freeDomain === $emailDomain) {
+            $isPattern = false !== stripos($freeDomain, '*');
+
+            if (!$isPattern && $freeDomain === $emailDomain) {
                 return true;
             }
 
-            if (fnmatch($freeDomain, $emailDomain)) {
+            if ($isPattern && fnmatch($freeDomain, $emailDomain)) {
                 return true;
             }
         }


### PR DESCRIPTION
Most domains in the list are not pattern, and so don't need to be checked with `fnmatch` at all.